### PR TITLE
Fix closest entities selection to enforce limit

### DIFF
--- a/src/main/java/ru/hmp/simulation/map/TwoHashMapsSimulationMap.java
+++ b/src/main/java/ru/hmp/simulation/map/TwoHashMapsSimulationMap.java
@@ -169,8 +169,8 @@ public class TwoHashMapsSimulationMap implements SimulationMap {
                     int distance = Math.max(Math.abs(position.getX() - getEntityPosition(entity).getX()),
                             Math.abs(position.getY() - getEntityPosition(entity).getY()));
 
-                    if (queue.size() > number) {
-                        if (distance < queue.peek().distance) {
+                    if (queue.size() >= number) {
+                        if (!queue.isEmpty() && distance < queue.peek().distance) {
                             queue.poll();
                             queue.add(new PositionDistancePair(entity, distance));
                         }
@@ -178,6 +178,11 @@ public class TwoHashMapsSimulationMap implements SimulationMap {
                         queue.add(new PositionDistancePair(entity, distance));
                     }
                 });
+
+        while (queue.size() > number) {
+            queue.poll();
+        }
+
         return queue.stream().
                 map(positionDistancePair -> positionDistancePair.entity).
                 collect(Collectors.toList());


### PR DESCRIPTION
## Summary
- ensure getNClosestEntities removes the farthest entity before inserting a closer one once the queue limit is reached
- trim the priority queue after traversal so the returned list never exceeds the requested number of entities

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin:3.3.1 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cbce143568832ab96303b06dbdf5e5